### PR TITLE
Decode percent-encoded file URLs in QGetFilePath

### DIFF
--- a/ifaces/qUtils.cpp
+++ b/ifaces/qUtils.cpp
@@ -26,6 +26,7 @@
 #include <QCryptographicHash>
 #include <QHash>
 #include <QJsonDocument>
+#include <QUrl>
 #include <boost/algorithm/string.hpp>
 
 QString qUtils::deviceId() {
@@ -132,6 +133,13 @@ QString qUtils::QAddressToScriptPubKey(const QString &address) {
 QString qUtils::QGetFilePath(QString in) {
     if (in.isEmpty() || in == "") {
         return "";
+    }
+    // QML file dialogs return percent-encoded URLs ("%20" for spaces, "%23"
+    // for '#'). Stripping the scheme keeps the encoding and the path lookup
+    // fails, so decode through QUrl for local files.
+    QUrl url(in);
+    if (url.isLocalFile()) {
+        return url.toLocalFile();
     }
 #ifdef _WIN32
     return in.remove("file:///");


### PR DESCRIPTION
Fixes #119

The QML file dialog returns percent-encoded file:// URLs and QGetFilePath only strips the scheme, so any file name with spaces, '#' or brackets resolves to a path that doesn't exist and wallet recovery fails with [-1017] Invalid descriptor. The default group wallet backup name has all three characters.

Decode local file URLs with QUrl::toLocalFile() instead. Tested on macOS arm64: recovering '[Group wallet #4]_backup.bsms' fails on main and works with this change.